### PR TITLE
Feature/faiss index caching

### DIFF
--- a/model_configs/README.md
+++ b/model_configs/README.md
@@ -1,0 +1,67 @@
+## 🔍 FAISS Index Reuse for RAG Evaluation
+
+This fork adds support for **reusing or saving FAISS indexes** during RAG evaluations in LightEval, dramatically improving speed and avoiding redundant recomputation.
+
+### ✨ Why This Matters
+
+By default, LightEval rebuilds the FAISS index **every run**, even if your dataset and embedding model are unchanged. With this update, you can:
+- Load a previously computed FAISS index from disk
+- Save the index the first time it's built
+- Avoid recomputing embeddings and chunk processing unnecessarily
+
+---
+
+### 🔧 How to Use
+
+To activate FAISS index reuse, modify your `rag_model.yaml` file as follows:
+
+```yaml
+rag_params:
+    embedding_model: "thenlper/gte-small" 
+    docs_name_or_path: "m-ric/huggingface_doc" 
+    similarity_fn: cosine 
+    top_k: 20
+    num_chunks: 100000
+    faiss_index_path: "./faiss_cache/my_index.index"
+```
+
+#### ✅ `faiss_index_path`
+- **If this path exists**, the index will be loaded from disk using `FAISS.load_local(...)`.
+- **If it doesn't exist**, the index will be built from `docs_name_or_path`, then saved to this path using `vector_db.save_local(...)`.
+
+> Example:
+```yaml
+faiss_index_path: "indexes/wiki_stem_faiss_index"
+```
+
+This will create `wiki_stem_faiss_index/index.faiss` and `index.pkl`.
+
+---
+
+### 🛠️ What Was Changed
+
+#### 1. `embed_model.py`
+- Added a `faiss_index_path` parameter in `EmbeddingModelConfig`.
+- Modified `_build_knowledge_base(...)` to check if the FAISS index should be loaded or built and saved.
+
+#### 2. `main_accelerate.py`
+- Extracts `faiss_index_path` from the `rag_params` config block and passes it to the model config.
+
+---
+
+### ✅ Benefits
+
+- ⏱️ **Faster**: Skips re-embedding and chunking for static datasets
+- 💾 **Cacheable**: Can be reused across multiple model evaluations
+- 🧪 **Modular**: Keeps FAISS logic inside the embedding model where it belongs
+
+---
+
+### 💡 Tips
+
+- You must ensure the embedding model and dataset used match the FAISS index — otherwise, results will be unreliable.
+- The `faiss_index_path` directory will be created if it doesn't exist.
+
+---
+
+This addition makes RAG evaluation workflows faster and more reproducible.

--- a/model_configs/rag_model.yaml
+++ b/model_configs/rag_model.yaml
@@ -15,6 +15,7 @@ model:
     similarity_fn: cosine # Select the similarity function to use, options are: cosine, dot_product, max_inner_product, jaccard
     top_k: 20 # Choose the number of documents to retrieve
     num_chunks: 100000 # This is the limit we set for the number of chunks to retrieve from the document where each chunk is 512 tokens
+    faiss_index_path: "./faiss_cache/my_index.index"
 
   # Ignore this section, do not modify!
   merged_weights:

--- a/src/lighteval/main_accelerate.py
+++ b/src/lighteval/main_accelerate.py
@@ -217,6 +217,8 @@ def accelerate(  # noqa C901
             rag_model_config.top_k = config["rag_params"]["top_k"]
             rag_model_config.similarity_fn = config["rag_params"]["similarity_fn"]
             rag_model_config.num_chunks = config["rag_params"]["num_chunks"]
+            rag_model_config.faiss_index_path = config["rag_params"].get("faiss_index_path", None)
+
     else:
         model_args_dict: dict = {k.split("=")[0]: k.split("=")[1] if "=" in k else True for k in model_args.split(",")}
         model_args_dict["accelerator"] = accelerator


### PR DESCRIPTION
## 🚀 Add Optional FAISS Index Caching to RAG Evaluations

### 📌 Summary

This PR adds the ability to reuse or save FAISS indexes in RAG mode, reducing repeated embedding and chunking overhead when running multiple evaluations on the same dataset.

### ✅ Key Features
- New config option: `faiss_index_path` under `rag_params`
- Automatically:
  - Loads existing index if available
  - Saves new index to disk for reuse
- Fully backward compatible — if no path is provided, behavior remains unchanged

### 🔧 Modified Files
- `main_accelerate.py`: Passes `faiss_index_path` from YAML
- `embed_model.py`: Builds or loads FAISS index based on the given path

### 🧪 Tested
- Run once: builds & saves FAISS index
- Run again: loads index successfully and skips rebuild

### 📁 Example `rag_model.yaml`
```yaml
rag_params:
  embedding_model: "BAAI/bge-base-en"
  docs_name_or_path: "your_dataset"
  top_k: 5
  num_chunks: 100000
  similarity_fn: "cosine"
  faiss_index_path: "indexes/my_index"

